### PR TITLE
Re authenticate

### DIFF
--- a/classes/NMLAddressing.sc
+++ b/classes/NMLAddressing.sc
@@ -346,7 +346,7 @@ Registrar {
 				// tell everyone about the new arrival
 				addrBook.sendAll(oscPath ++ "-add", peer.name, addr.ip, addr.port);
 				// tell the new arrival about everyone
-				addrBook.peers.do({|peer|
+				addrBook.excluding(peer.name).do({|peer|
 					addr.sendMsg(oscPath ++ "-add", peer.name, peer.addr.ip, peer.addr.port);
 				});
 				addrBook.add(peer);

--- a/classes/NMLAddressing.sc
+++ b/classes/NMLAddressing.sc
@@ -24,6 +24,12 @@ Peer {
 
 	online_ {|bool| if(bool != online, { online = bool; this.changed(\online) }) }
 
+	// may be needed if a Peer has recompiled and has a new port
+	addr_ {|newAddr|
+		addr = newAddr;
+		this.changed(\addr);
+	}
+
 	== {|other|
 		^this.name == other.name && {this.addr.matches(other.addr)};
 	}

--- a/classes/NMLAddressing.sc
+++ b/classes/NMLAddressing.sc
@@ -424,7 +424,7 @@ Registrant {
 			var peer;
 			if(addrBook[msg[1]].notNil, {
 				"Peer % rejoined the Utopia\n".postf(msg[1]);
-				addrBook[msg[1]].addr = addr;
+				addrBook[msg[1]].addr = NetAddr(msg[2].asString, msg[3]);
 			}, {
 				peer = this.makePeer(*msg[1..]);
 				addrBook.add(peer);


### PR DESCRIPTION
Hi All,

I'm trying to clean things up and squash any bugs in advance of the Utopia workshop at ICLC next week.

This addresses Issue #9.

Basically if a Peer of a given name attempts to re-join the Utopia (either via Hail or Registar/-stant) it reauthenticates and replaces the Peer's address, posting a warning.

I'd like to merge this (and a couple of others) in the next day or two.

