### PR TITLE
Peer: Rework and improve *defaultName

### DIFF
--- a/classes/NMLAddressing.sc
+++ b/classes/NMLAddressing.sc
@@ -19,7 +19,17 @@ Peer {
 	}
 
 	*defaultName {
-		^"whoami".unixCmdGetStdOut.replace("\n", "");
+		var cmd, name;
+		cmd = Platform.case(
+			    \osx,       { "id -un" },
+			    \linux,     { "id -un" },
+			    \windows,   { "echo %username%" },
+			{""}
+		);
+		name = cmd.unixCmdGetStdOut;
+		if(name.size == 0, { name ="hostname".unixCmdGetStdOut });
+		name = name.replace("\n", "");
+		^name;
 	}
 
 	online_ {|bool| if(bool != online, { online = bool; this.changed(\online) }) }


### PR DESCRIPTION
The single commit in this PR does the following:

- whoami is deprecated, and has been replaced with id for osx and windows
- use "echo %username%" on Windows as availability of whom is limited on windows
- fall back on hostname if for some reason it doesn't work

This will hopefully solve a problem where whomami seemed to return an empty string for some reason.

NB I don't have a reproducer for the problem, but it seems to be gone, and I haven't been able to test the new version on Windows (@bagong maybe you could help?), though I've confirmed the cl command works.
Signed-off-by: Scott Wilson <i@scottwilson.ca>