### PR TITLE
add Republic Server

### DIFF
--- a/classes/Repulque/RepublicServer.sc
+++ b/classes/Repulque/RepublicServer.sc
@@ -1,0 +1,64 @@
+
+RepublicServer : Server {
+
+	var <serverRegistry, <serverMappings;
+	var <>sortFunc;
+
+	// need to update when hail detects changing topology
+	serverRegistry_ { |sreg|
+		var indices, keys;
+		serverRegistry = sreg;
+		// the first time, sort alphabetically
+		if(serverMappings.isNil or: { sortFunc.notNil }) {
+			keys = serverRegistry.keys.as(Array).sort(sortFunc);
+			serverMappings = keys.collect { |x| serverRegistry[x] };
+		} {
+			// then just append
+			sreg.pairsDo { |key, val|
+				if(serverMappings.includes(val).not) {
+					serverMappings = serverMappings.add(val)
+				}
+			};
+			serverMappings.removeAllSuchThat { |x| sreg.includes(x).not }
+		}
+	}
+
+	resolveAddr { |msg|
+		var where, which, otherAddr;
+	//	msg.postcs;
+		where = msg.indexOf(\where);
+		if(where.notNil) {
+			which = msg[where + 1];
+			if(which.isNil or: { which == 0 }) {
+				^addr
+			} {
+				if(which.isNumber) {
+					^serverMappings @@ which
+				} {
+
+					otherAddr = serverRegistry.at(which);
+					if(otherAddr.notNil) {
+						^otherAddr
+					} {
+						"RepublicServer: server name '%' not registered".format(which).warn;
+					}
+				}
+			}
+		};
+		^addr
+	}
+
+	sendMsg { |... msg|
+		this.resolveAddr(msg).sendMsg(*msg)
+	}
+
+	sendBundle { |time ... msgs|
+		// use only first message for resolving it.
+		// later, we could search until we have found the first one.
+		this.resolveAddr(msgs.first).sendBundle(time, *msgs)
+	}
+
+
+
+}
+

--- a/classes/Repulque/extRepublicSynthDef.sc
+++ b/classes/Repulque/extRepublicSynthDef.sc
@@ -1,0 +1,40 @@
+
++ SynthDef {
+
+	manipulateSynthDescForRepublic {
+		var synthDesc = SynthDescLib.at(this.name);
+		var ctl = synthDesc.controlNames;
+		synthDesc !? {
+			if(ctl.isNil or: { synthDesc.controlNames.includes("where").not }) {
+				synthDesc.controlNames = synthDesc.controlNames.add("where");
+				synthDesc.controls = synthDesc.controls.add(
+					ControlName().name_('where').defaultValue_(0);
+				);
+				synthDesc.makeMsgFunc; // again
+			};
+		}
+	}
+
+	earmark { arg libname, completionMsg, keepDef = true;
+		this.add(libname, completionMsg, keepDef);
+		this.manipulateSynthDescForRepublic;
+	}
+
+
+	/*
+	add { arg libname, completionMsg, keepDef = true;
+		var	servers, desc = this.asSynthDesc(libname ? \global, keepDef);
+		this.manipulateSynthDescForRepublic;
+		if(libname.isNil) {
+			servers = Server.allRunningServers
+		} {
+			servers = SynthDescLib.getLib(libname).servers
+		};
+		servers.do { |each|
+			this.doSend(each.value, completionMsg.value(each))
+		}
+	}
+	*/
+
+
+}


### PR DESCRIPTION
This adds original Republic functionality, which allows us to locate in
any OSC message a dispatcher to registered servers.

We just tested it and it runs nicely. A little under-the-hood, but very expressive. If you like it, we can also add documentation …

you can write stuff like `Pbind(\where, Pseq([0, 5, 1], inf))`, which sends to the first, fourth, and second participant. Maybe we could reintroduce `\all` again.