### PR TITLE
BeaconClock: Add 'numPeers' (from Ableton spec) for future SCClockMeterSync

### DIFF
--- a/classes/NMLClock.sc
+++ b/classes/NMLClock.sc
@@ -299,4 +299,7 @@ BeaconClock : TempoClock {
 		if(bool, {CmdPeriod.add(this)}, {CmdPeriod.remove(this)});
 		super.permanent_(bool);
 	}
+
+	// for compatibility with SCClockMeterSync (to sync up barlines)
+	numPeers { ^addrBook.onlinePeers.size }
 }


### PR DESCRIPTION
Just throwing this out there while I'm thinking about it.

If you add the single-line method proposed here, then BeaconClock will be able to use a class that will be introduced in an upcoming SC release, to ensure that barlines and beatsPerBar match across the network. (The new class[1] is originally for LinkClock, but except for `numPeers` from LinkClock, it only uses standard TempoClock methods, so in principle it should be compatible with other beat-syncing clocks that follow TempoClock's interface. I tested, and BeaconClock actually passed! So, +1 for object-oriented decoupling.)

Scott, I remember I had asked you about barlines once before. This might actually take care of that.

```
a = AddrBook.new;
h = Hail(a, me: \peer1);
c = BeaconClock(a);
m = SCClockMeterSync(c);
```

[1] https://github.com/supercollider/supercollider/blob/343d4300746b218dab3e0e792cb787ecf10737dd/SCClassLibrary/External/Ableton/SCClockMeterSync.sc